### PR TITLE
SOFTWARE-5735: run write-signed-rpm after signing

### DIFF
--- a/post_sign.py
+++ b/post_sign.py
@@ -9,21 +9,36 @@ from configparser import ConfigParser
 # Configuration file in /etc like for other plugins
 config_file = '/etc/koji-hub/plugins/sign.conf'
 
+logger = logging.getLogger('koji.plugin.post_sign')
+
 
 def post_sign(cbType, sigkey=None, sighash=None, build=None, rpm=None):
     """ Run the kojihub write-signed-rpm command on rpms after they've been signed with a signing key,
     which is required for generating repos that use a specific key.
     """
+    if sigkey is None or sighash is None or build is None or rpm is None:
+        logger.warning("Got unexpected None argument to post_sign plugin. Skipping")
+        return
+
+    if 'buildroot_id' not in rpm or 'nvr' not in build:
+        logger.warning("Expected keys missing from plugin arguments. Skipping")
+        return
+
     buildroot = kojihub.get_buildroot(rpm['buildroot_id'])
+
+    if buildroot is None or 'tag_name' not in buildroot:
+        logger.warning("No tag name found for build. Skipping")
+        return
+
     tag_name = buildroot['tag_name']
-    logging.getLogger('koji.plugin.sign').info("Running post-sign plugin for package with tag_name %s", tag_name)
+    logger.info("Running post-sign plugin for build %s with tag_name %s", build['nvr'], tag_name)
 
     config = ConfigParser()
     config.read(config_file)
     
     if not config.has_option(tag_name, "strict_keys") or not config.getboolean(tag_name, "strict_keys"):
         # Only need to write-signed-rpm for repos with strict signing enabled
-        logging.getLogger('koji.plugin.sign').info("tag_name %s doesn't have strict signing enabled. Skipping.", tag_name)
+        logger.info("tag_name %s doesn't have strict signing enabled. Skipping.", tag_name)
         return
     
 

--- a/post_sign.py
+++ b/post_sign.py
@@ -1,0 +1,33 @@
+# Koji callback for writing signed rpms after signing via sign.py
+# Required for package generation with strict keys in mash
+
+from koji.plugin import register_callback
+import kojihub
+import logging
+from configparser import ConfigParser
+
+# Configuration file in /etc like for other plugins
+config_file = '/etc/koji-hub/plugins/sign.conf'
+
+
+def post_sign(cbType, sigkey=None, sighash=None, build=None, rpm=None):
+    """ Run the kojihub write-signed-rpm command on rpms after they've been signed with a signing key,
+    which is required for generating repos that use a specific key.
+    """
+    buildroot = kojihub.get_buildroot(rpm['buildroot_id'])
+    tag_name = buildroot['tag_name']
+    logging.getLogger('koji.plugin.sign').info("Running post-sign plugin for package with tag_name %s", tag_name)
+
+    config = ConfigParser()
+    config.read(config_file)
+    
+    if not config.has_option(tag_name, "strict_keys") or not config.getboolean(tag_name, "strict_keys"):
+        # Only need to write-signed-rpm for repos with strict signing enabled
+        logging.getLogger('koji.plugin.sign').info("tag_name %s doesn't have strict signing enabled. Skipping.", tag_name)
+        return
+    
+
+    kojihub.write_signed_rpm(rpm, sigkey)
+    logging.getLogger('koji.plugin.sign').info("write-signed-rpm task run successfully.")
+
+register_callback('postRPMSign', post_sign)

--- a/rpm/koji-plugin-sign.spec
+++ b/rpm/koji-plugin-sign.spec
@@ -1,6 +1,6 @@
 Name:           koji-plugin-sign
 Version:        1.4.0
-Release:        14%{?dist}
+Release:        15%{?dist}
 Summary:        GPG signing plugin for koji-hub
 
 Group:          Applications/System
@@ -33,6 +33,7 @@ exit 0
 mkdir -p $RPM_BUILD_ROOT
 install -D sign.conf -m 0600 $RPM_BUILD_ROOT/etc/koji-hub/plugins/sign.conf
 install -D sign.py -m 0755 $RPM_BUILD_ROOT/usr/lib/koji-hub-plugins/sign.py
+install -D post_sign.py -m 0755 $RPM_BUILD_ROOT/usr/lib/koji-hub-plugins/post_sign.py
 
 
 %files
@@ -42,6 +43,9 @@ install -D sign.py -m 0755 $RPM_BUILD_ROOT/usr/lib/koji-hub-plugins/sign.py
 
 
 %changelog
+* Fri Oct 27 2023 Matt Westphall <westphall@wisc.edu> - 1.4.0-15
+- Add callback to run koji write-signed-rpm after signing
+
 * Mon Oct 16 2023 Matt Westphall <westphall@wisc.edu> - 1.4.0-14
 - Re-add more robust error checking for new prompts
 

--- a/sign.py
+++ b/sign.py
@@ -11,13 +11,19 @@ import os
 import pexpect
 import re
 
+# Get the tag name from the buildroot map
+import sys
+sys.path.insert(0, '/usr/share/koji-hub')
+from kojihub import get_buildroot
+
 # Configuration file in /etc like for other plugins
 config_file = '/etc/koji-hub/plugins/sign.conf'
 
 GPG_EXPECTS = ['Enter passphrase:', pexpect.EOF, 'failed', 'skipping', 'error', pexpect.TIMEOUT]
 ERROR_MESSAGES = {
-    3: 'Package signing failed!',
-    4: 'Package signing skipped!',
+    2: 'Package signing failed!',
+    3: 'Package signing skipped!',
+    4: 'Package signing error!',
     5: 'Package signing timed out!'
 }
 
@@ -25,10 +31,6 @@ def sign(cbtype, *args, **kws):
     if kws['type'] != 'build':
        return
 
-    # Get the tag name from the buildroot map
-    import sys
-    sys.path.insert(0, '/usr/share/koji-hub')
-    from kojihub import get_buildroot
     br_id = list(kws['brmap'].values())[0]
     br = get_buildroot(br_id)
     tag_name = br['tag_name']


### PR DESCRIPTION
- Add a second plugin that runs koji write-signed-rpm on rpms after signing, toggleable via a new conf file option
- Correct error message key-value pairs in existing plugin